### PR TITLE
Fix update for the covered "Next" button

### DIFF
--- a/code/FmCart.js
+++ b/code/FmCart.js
@@ -126,6 +126,10 @@ class FmCart {
 				this.#selectItem(row, id, selectedItems, columns, table);
 
 			});
+			
+			// append table to cart container
+			let fmCartContainer = document.querySelector('.fm-cart-container');
+			fmCartContainer.appendChild(table);
 
 
 

--- a/index.js
+++ b/index.js
@@ -32,7 +32,13 @@ function initializePicker(config, requestData = true) {
 
 	// create parent element
 	const parentElement = document.createElement('div');
+	parentElement.className = 'fm-results-list';
 	document.body.appendChild(parentElement);
+
+	// create div to hold cart
+	const div = document.createElement('div');
+	div.className = 'fm-cart-container';
+	document.body.appendChild(div);
 
 	// create table
 	fmResultsList = new FmResultsList(parentElement, columns, request);

--- a/styles/FmResults_Cart.css
+++ b/styles/FmResults_Cart.css
@@ -109,6 +109,117 @@ table button {
     margin: 0;
     border: none;
     background-color: transparent;
-    /* collapse */
+    text-align: center;
+     /* collapse */
     border-collapse: collapse;
+}
+
+/* put pagination buttons next to each other in row */
+tfoot td {
+    display: flex;
+    justify-content: space-between;
+}
+
+/* style footer buttons */
+tfoot button {
+    background-color: transparent;
+    border: none;
+    color: #4b4b4b;
+    padding: 2px 10px;
+    text-decoration: none;
+    font-size: 1em;
+    font-family: sans-serif;
+    cursor: pointer;
+    width: 50%;
+}
+
+.next-button {
+    text-align: right;
+}
+
+.previous-button {
+    text-align: left;
+}
+
+/* keep the cart visible at bottom of screen */
+.fm-cart {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    background-color: #ffffff;
+    color: #4b4b4b;
+    text-align: left;
+    padding: 0;
+}
+
+/* Make the table headers capitalized */
+.styled-table th {
+    text-transform: capitalize;
+}
+
+/* 
+    Center the last column (Add and Remove to cart buttons).
+    You can comment this section if you don't need to center the last column.
+*/
+.last-column {
+    text-align: center;
+}
+
+/* style buttons to be square and fill cell*/
+table button {
+    width: 100%;
+    height: 100%;
+    border: none;
+    font-size: 1em;
+    font-family: sans-serif;
+    cursor: pointer;
+    border-radius: 0;
+    background-color: transparent;
+    text-align: center;
+}
+
+/* put pagination buttons next to each other in row */
+tfoot td {
+    display: flex;
+    justify-content: space-between;
+}
+
+/* style footer buttons */
+tfoot button {
+    background-color: transparent;
+    border: none;
+    color: #4b4b4b;
+    padding: 2px 10px;
+    text-decoration: none;
+    font-size: 1em;
+    font-family: sans-serif;
+    cursor: pointer;
+    width: 50%;
+}
+
+.next-button {
+    text-align: right;
+}
+
+.previous-button {
+    text-align: left;
+}
+
+/* keep the cart visible at bottom of screen */
+.fm-cart {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    background-color: #ffffff;
+    color: #4b4b4b;
+}
+
+.fm-results-list{
+    max-height: 500px !important;
+    overflow-y: scroll;
+}
+
+.fm-cart-container{
+    max-height: 300px !important;
+    overflow-y: scroll;
 }


### PR DESCRIPTION
### **Changelogs**

- Added a parent `<div>` with class name `fm-cart-container` to the **fm-cart** table
- Added a max-height styling to the results list table to keep the cart and the results list from overlapping, which causes the "Next" button to be covered behind the cart
- Added a vertical scroll on both table to apply a fixed height on each tables